### PR TITLE
feat: Implement CRUD operations for Warframe entity

### DIFF
--- a/CodexApi/CodexApi.http
+++ b/CodexApi/CodexApi.http
@@ -1,7 +1,53 @@
 @CodexApi_HostAddress = http://localhost:8082
 
 ### Get Warframe by ID
-GET {{CodexApi_HostAddress}}/api/v1/warframes/dcb7754d-9e0b-4dc9-a42e-0382aded6ce4
+GET {{CodexApi_HostAddress}}/api/v1/warframes/{id}
 Accept: application/json
 
-###
+### Create a new Warframe
+POST {{CodexApi_HostAddress}}/api/v1/warframes
+Content-Type: application/json
+
+{
+  "name": "Excalibur",
+  "rol": "Balanced",
+  "rank": 30,
+  "stats": {
+    "hp": 300,
+    "shield": 225,
+    "armor": 225,
+    "energy": 150
+  }
+}
+
+### Update a Warframe (PUT)
+PUT {{CodexApi_HostAddress}}/api/v1/warframes/{id}
+Content-Type: application/json
+
+{
+  "name": "Excalibur Prime",
+  "rol": "Balanced",
+  "rank": 30,
+  "stats": {
+    "hp": 350,
+    "shield": 275,
+    "armor": 275,
+    "energy": 200
+  }
+}
+
+### Partially update a Warframe (PATCH)
+PATCH {{CodexApi_HostAddress}}/api/v1/warframes/{id}
+Content-Type: application/json
+
+{
+  "name": "Excalibur Umbra",
+  "stats": {
+    "hp": 400
+  }
+}
+
+### Delete a Warframe
+DELETE {{CodexApi_HostAddress}}/api/v1/warframes/{id}
+
+docker run --name codex-api -d -p 8082:8080 codex-api:3

--- a/CodexApi/Controllers/WarframesController.cs
+++ b/CodexApi/Controllers/WarframesController.cs
@@ -2,9 +2,13 @@ using Microsoft.AspNetCore.Mvc;
 using CodexApi.Dtos;
 using CodexApi.Services;
 using CodexApi.Mappers;
+using CodexApi.Exceptions;
 
 namespace CodexApi.Controllers;
 
+/// <summary>
+/// Controller for managing Warframe operations
+/// </summary>
 [ApiController]
 [Route("api/v1/[controller]")]
 public class WarframesController : ControllerBase
@@ -16,13 +20,195 @@ public class WarframesController : ControllerBase
         _warframeService = warframeService;
     }
 
-    [HttpGet("{id}", Name = "GetWarframeByIdAsync")]
+    [HttpGet("{id}")]
     [ProducesResponseType(typeof(WarframeResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<WarframeResponse>> GetWarframeByIdAsync(Guid id, CancellationToken cancellationToken)
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<WarframeResponse>> GetWarframeById(Guid id, CancellationToken cancellationToken)
     {
-        var warframe = await _warframeService.GetWarframeByIdAsync(id, cancellationToken);
-        return warframe is null ? NotFound() : Ok(warframe.ToResponse());
+        if (id == Guid.Empty)
+        {
+            return BadRequest(new { message = "Invalid Warframe ID. ID cannot be empty." });
+        }
+
+        try
+        {
+            var warframe = await _warframeService.GetWarframeByIdAsync(id, cancellationToken);
+            return Ok(warframe.ToResponse());
+        }
+        catch (WarframeNotFoundException ex)
+        {
+            return NotFound(new { message = ex.Message });
+        }
+    }
+
+
+    [HttpGet(Name = "GetWarframesAsync")]
+    [ProducesResponseType(typeof(IEnumerable<WarframeResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<IEnumerable<WarframeResponse>>> GetWarframesAsync(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10,
+        [FromQuery] string name = "",
+        CancellationToken cancellationToken = default)
+    {
+        var warframes = await _warframeService.GetWarframesAsync(page, pageSize, name, cancellationToken);
+        var response = warframes.Select(w => w.ToResponse());
+        
+        return Ok(response);
+    }
+
+
+    [HttpPost]
+    [ProducesResponseType(typeof(WarframeResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<WarframeResponse>> CreateWarframe(
+        [FromBody] CreateWarframeRequest request,
+        CancellationToken cancellationToken)
+    {
+        //revisar si el modelo de warframe es corecto, de lo contrario retorna 400
+        if (!ModelState.IsValid)
+        {
+            var errors = ModelState
+                .Where(x => x.Value?.Errors.Count > 0)
+                .ToDictionary(
+                    kvp => kvp.Key.ToLowerInvariant(),
+                    kvp => kvp.Value?.Errors.Select(e => e.ErrorMessage).ToArray() ?? Array.Empty<string>()
+                );
+
+            return BadRequest(new { message = "Validation failed", errors });
+        }
+
+        try
+        {
+            var warframe = await _warframeService.CreateWarframeAsync(request, cancellationToken);
+            var response = warframe.ToResponse();
+            return CreatedAtAction(nameof(GetWarframeById), new { id = response.Id }, response);
+        }
+        catch (WarframeAlreadyExistsException ex)
+        {
+            return Conflict(new { message = ex.Message });
+        }
+        catch (ValidationException ex)
+        {
+            return BadRequest(new { message = ex.Message, errors = ex.Errors });
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    [HttpPut("{id}")]
+    [ProducesResponseType(typeof(WarframeResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<WarframeResponse>> UpdateWarframe(
+        Guid id,
+        [FromBody] UpdateWarframeRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (id == Guid.Empty)
+        {
+            return BadRequest(new { message = "Invalid Warframe ID. ID cannot be empty." });
+        }
+
+        if (!ModelState.IsValid)
+        {
+            var errors = ModelState
+                .Where(x => x.Value?.Errors.Count > 0)
+                .ToDictionary(
+                    kvp => kvp.Key.ToLowerInvariant(),
+                    kvp => kvp.Value?.Errors.Select(e => e.ErrorMessage).ToArray() ?? Array.Empty<string>()
+                );
+
+            return BadRequest(new { message = "Validation failed", errors });
+        }
+
+        try
+        {
+            var warframe = await _warframeService.UpdateWarframeAsync(id, request, cancellationToken);
+            return Ok(warframe.ToResponse());
+        }
+        catch (WarframeNotFoundException ex)
+        {
+            return NotFound(new { message = ex.Message });
+        }
+        catch (ValidationException ex)
+        {
+            return BadRequest(new { message = ex.Message, errors = ex.Errors });
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    [HttpPatch("{id}")]
+    [ProducesResponseType(typeof(WarframeResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<WarframeResponse>> PatchWarframe(
+        Guid id,
+        [FromBody] PatchWarframeRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (id == Guid.Empty)
+        {
+            return BadRequest(new { message = "Invalid Warframe ID. ID cannot be empty." });
+        }
+
+        if (!ModelState.IsValid)
+        {
+            var errors = ModelState
+                .Where(x => x.Value?.Errors.Count > 0)
+                .ToDictionary(
+                    kvp => kvp.Key.ToLowerInvariant(),
+                    kvp => kvp.Value?.Errors.Select(e => e.ErrorMessage).ToArray() ?? Array.Empty<string>()
+                );
+
+            return BadRequest(new { message = "Validation failed", errors });
+        }
+
+        try
+        {
+            var warframe = await _warframeService.PatchWarframeAsync(id, request, cancellationToken);
+            return Ok(warframe.ToResponse());
+        }
+        catch (WarframeNotFoundException ex)
+        {
+            return NotFound(new { message = ex.Message });
+        }
+        catch (ValidationException ex)
+        {
+            return BadRequest(new { message = ex.Message, errors = ex.Errors });
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    [HttpDelete("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> DeleteWarframe(Guid id, CancellationToken cancellationToken)
+    {
+        if (id == Guid.Empty)
+        {
+            return BadRequest(new { message = "Invalid Warframe ID. ID cannot be empty." });
+        }
+
+        try
+        {
+            await _warframeService.DeleteWarframeAsync(id, cancellationToken);
+            return NoContent();
+        }
+        catch (WarframeNotFoundException ex)
+        {
+            return NotFound(new { message = ex.Message });
+        }
     }
 }

--- a/CodexApi/Dtos/CreateWarframeRequest.cs
+++ b/CodexApi/Dtos/CreateWarframeRequest.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace CodexApi.Dtos;
+
+public class CreateWarframeRequest
+{
+    [Required(ErrorMessage = "Name is required")]
+    [StringLength(100, ErrorMessage = "Name cannot exceed 100 characters")]
+    public string Name { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Role is required")]
+    [StringLength(50, ErrorMessage = "Role cannot exceed 50 characters")]
+    public string Rol { get; set; } = string.Empty;
+
+    [Range(0, 30, ErrorMessage = "Rank must be between 0 and 30")]
+    public int Rank { get; set; }
+
+    [Required]
+    public StatsRequest Stats { get; set; } = new();
+}
+
+public class StatsRequest
+{
+    [Range(1, 9999, ErrorMessage = "HP must be between 1 and 9999")]
+    public int Hp { get; set; }
+
+    [Range(0, 9999, ErrorMessage = "Shield must be between 0 and 9999")]
+    public int Shield { get; set; }
+
+    [Range(0, 9999, ErrorMessage = "Armor must be between 0 and 9999")]
+    public int Armor { get; set; }
+
+    [Range(1, 9999, ErrorMessage = "Energy must be between 1 and 9999")]
+    public int Energy { get; set; }
+}

--- a/CodexApi/Dtos/PatchWarframeRequest.cs
+++ b/CodexApi/Dtos/PatchWarframeRequest.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace CodexApi.Dtos;
+
+public class PatchWarframeRequest
+{
+    [StringLength(100, ErrorMessage = "Name cannot exceed 100 characters")]
+    public string? Name { get; set; }
+
+    [StringLength(50, ErrorMessage = "Role cannot exceed 50 characters")]
+    public string? Rol { get; set; }
+
+    [Range(0, 30, ErrorMessage = "Rank must be between 0 and 30")]
+    public int? Rank { get; set; }
+
+    public PatchStatsRequest? Stats { get; set; }
+}
+
+public class PatchStatsRequest
+{
+    [Range(1, 9999, ErrorMessage = "HP must be between 1 and 9999")]
+    public int? Hp { get; set; }
+
+    [Range(0, 9999, ErrorMessage = "Shield must be between 0 and 9999")]
+    public int? Shield { get; set; }
+
+    [Range(0, 9999, ErrorMessage = "Armor must be between 0 and 9999")]
+    public int? Armor { get; set; }
+
+    [Range(1, 9999, ErrorMessage = "Energy must be between 1 and 9999")]
+    public int? Energy { get; set; }
+}

--- a/CodexApi/Dtos/UpdateWarframeRequest.cs
+++ b/CodexApi/Dtos/UpdateWarframeRequest.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace CodexApi.Dtos;
+
+public class UpdateWarframeRequest
+{
+    [Required(ErrorMessage = "Name is required")]
+    [StringLength(100, ErrorMessage = "Name cannot exceed 100 characters")]
+    public string Name { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Role is required")]
+    [StringLength(50, ErrorMessage = "Role cannot exceed 50 characters")]
+    public string Rol { get; set; } = string.Empty;
+
+    [Range(0, 30, ErrorMessage = "Rank must be between 0 and 30")]
+    public int Rank { get; set; }
+
+    [Required]
+    public StatsRequest Stats { get; set; } = new();
+}

--- a/CodexApi/Exceptions/ValidationException.cs
+++ b/CodexApi/Exceptions/ValidationException.cs
@@ -1,0 +1,21 @@
+namespace CodexApi.Exceptions;
+
+public class ValidationException : Exception
+{
+    public IDictionary<string, string[]> Errors { get; }
+
+    public ValidationException(IDictionary<string, string[]> errors)
+        : base("One or more validation errors occurred.")
+    {
+        Errors = errors;
+    }
+
+    public ValidationException(string field, string error)
+        : base($"Validation error in field '{field}': {error}")
+    {
+        Errors = new Dictionary<string, string[]>
+        {
+            { field, new[] { error } }
+        };
+    }
+}

--- a/CodexApi/Exceptions/WarframeAlreadyExistsException.cs
+++ b/CodexApi/Exceptions/WarframeAlreadyExistsException.cs
@@ -1,0 +1,9 @@
+namespace CodexApi.Exceptions;
+
+public class WarframeAlreadyExistsException : Exception
+{
+    public WarframeAlreadyExistsException(string name) 
+        : base($"Warframe with name '{name}' already exists.")
+    {
+    }
+}

--- a/CodexApi/Exceptions/WarframeNotFoundException.cs
+++ b/CodexApi/Exceptions/WarframeNotFoundException.cs
@@ -1,0 +1,9 @@
+namespace CodexApi.Exceptions;
+
+public class WarframeNotFoundException : Exception
+{
+    public WarframeNotFoundException(Guid id) 
+        : base($"Warframe with ID '{id}' was not found.")
+    {
+    }
+}

--- a/CodexApi/Gateways/IWarframeGateway.cs
+++ b/CodexApi/Gateways/IWarframeGateway.cs
@@ -1,8 +1,14 @@
 using CodexApi.Models;
+using CodexApi.Dtos;
 
 namespace CodexApi.Gateways;
 
 public interface IWarframeGateway
 {
     Task<Warframe?> GetWarframeByIdAsync(Guid id, CancellationToken cancellationToken);
+    Task<IEnumerable<Warframe>> GetWarframesAsync(int page, int pageSize, string name, CancellationToken cancellationToken);
+    Task<Warframe> CreateWarframeAsync(CreateWarframeRequest request, CancellationToken cancellationToken);
+    Task<bool> UpdateWarframeAsync(Guid id, UpdateWarframeRequest request, CancellationToken cancellationToken);
+    Task<bool> PatchWarframeAsync(Guid id, PatchWarframeRequest request, CancellationToken cancellationToken);
+    Task<bool> DeleteWarframeAsync(Guid id, CancellationToken cancellationToken);
 }

--- a/CodexApi/Gateways/WarframeGateway.cs
+++ b/CodexApi/Gateways/WarframeGateway.cs
@@ -2,6 +2,8 @@ using System.ServiceModel;
 using CodexApi.Models;
 using CodexApi.Infrastructure.Soap.Contracts;
 using CodexApi.Infrastructure.Soap.Dtos;
+using CodexApi.Dtos;
+using CodexApi.Exceptions;
 
 namespace CodexApi.Gateways;
 
@@ -29,9 +31,158 @@ public class WarframeGateway : IWarframeGateway
 
             return ToModel(warframeDto);
         }
+        catch (System.ServiceModel.FaultException)
+        {
+            return null;
+        }
         catch (Exception)
         {
             return null;
+        }
+    }
+
+    public async Task<IEnumerable<Warframe>> GetWarframesAsync(int page, int pageSize, string name, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var channelFactory = new ChannelFactory<IWarframeServiceContract>(_binding, _endpoint);
+            var client = channelFactory.CreateChannel();
+
+            var pagedResult = await client.GetWarframes(page, pageSize, name, cancellationToken);
+            return pagedResult.Items.Select(ToModel);
+        }
+        catch (Exception)
+        {
+            return Enumerable.Empty<Warframe>();
+        }
+    }
+
+    public async Task<Warframe> CreateWarframeAsync(CreateWarframeRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var channelFactory = new ChannelFactory<IWarframeServiceContract>(_binding, _endpoint);
+            var client = channelFactory.CreateChannel();
+
+            var createDto = new CreateWarframeDto
+            {
+                Name = request.Name,
+                Rol = request.Rol,
+                Rank = request.Rank,
+                Stats = new Infrastructure.Soap.Dtos.StatsDto
+                {
+                    Hp = request.Stats.Hp,
+                    Shield = request.Stats.Shield,
+                    Armor = request.Stats.Armor,
+                    Energy = request.Stats.Energy
+                }
+            };
+
+            Console.WriteLine($"Sending CreateWarframeDto: Name={createDto.Name}, Rol={createDto.Rol}, Rank={createDto.Rank}");
+            Console.WriteLine($"Stats: Hp={createDto.Stats?.Hp}, Shield={createDto.Stats?.Shield}, Armor={createDto.Stats?.Armor}, Energy={createDto.Stats?.Energy}");
+
+            var warframeDto = await client.CreateWarframe(createDto, cancellationToken);
+            return ToModel(warframeDto);
+        }
+        catch (System.ServiceModel.FaultException ex) when (ex.Message.Contains("already exists"))
+        {
+            // Convert SOAP FaultException to our custom exception for name conflicts
+            throw new WarframeAlreadyExistsException(ex.Message);
+        }
+    }
+
+    public async Task<bool> UpdateWarframeAsync(Guid id, UpdateWarframeRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var channelFactory = new ChannelFactory<IWarframeServiceContract>(_binding, _endpoint);
+            var client = channelFactory.CreateChannel();
+
+            var updateDto = new CreateWarframeDto
+            {
+                Name = request.Name,
+                Rol = request.Rol,
+                Rank = request.Rank,
+                Stats = new Infrastructure.Soap.Dtos.StatsDto
+                {
+                    Hp = request.Stats.Hp,
+                    Shield = request.Stats.Shield,
+                    Armor = request.Stats.Armor,
+                    Energy = request.Stats.Energy
+                }
+            };
+
+            var response = await client.UpdateWarframe(id, updateDto, cancellationToken);
+            return response != null;
+        }
+        catch (System.ServiceModel.FaultException ex) when (ex.Message.Contains("not found") || ex.Message.Contains("ID found"))
+        {
+            throw new WarframeNotFoundException(id);
+        }
+        catch (System.ServiceModel.FaultException ex) when (ex.Message.Contains("already exists"))
+        {
+            throw new WarframeAlreadyExistsException(ex.Message);
+        }
+    }
+
+    public async Task<bool> PatchWarframeAsync(Guid id, PatchWarframeRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var channelFactory = new ChannelFactory<IWarframeServiceContract>(_binding, _endpoint);
+            var client = channelFactory.CreateChannel();
+
+            var patchDto = new CreateWarframeDto
+            {
+                Name = request.Name ?? string.Empty,
+                Rol = request.Rol ?? string.Empty,
+                Rank = request.Rank ?? 0,
+                Stats = request.Stats != null ? new Infrastructure.Soap.Dtos.StatsDto
+                {
+                    Hp = request.Stats.Hp ?? 0,
+                    Shield = request.Stats.Shield ?? 0,
+                    Armor = request.Stats.Armor ?? 0,
+                    Energy = request.Stats.Energy ?? 0
+                } : new Infrastructure.Soap.Dtos.StatsDto()
+            };
+
+            Console.WriteLine($"Sending PatchWarframeDto: Name='{patchDto.Name}', Rol='{patchDto.Rol}', Rank={patchDto.Rank}");
+            Console.WriteLine($"Stats: Hp={patchDto.Stats?.Hp}, Shield={patchDto.Stats?.Shield}, Armor={patchDto.Stats?.Armor}, Energy={patchDto.Stats?.Energy}");
+
+            var response = await client.PatchWarframe(id, patchDto, cancellationToken);
+            return response != null;
+        }
+        catch (System.ServiceModel.FaultException ex) when (ex.Message.Contains("not found") || ex.Message.Contains("ID found"))
+        {
+            throw new WarframeNotFoundException(id);
+        }
+        catch (System.ServiceModel.FaultException ex) when (ex.Message.Contains("already exists"))
+        {
+            throw new WarframeAlreadyExistsException(ex.Message);
+        }
+    }
+
+    public async Task<bool> DeleteWarframeAsync(Guid id, CancellationToken cancellationToken)
+    {
+        try
+        {
+            Console.WriteLine($"Gateway: Attempting to delete Warframe with ID {id}");
+            using var channelFactory = new ChannelFactory<IWarframeServiceContract>(_binding, _endpoint);
+            var client = channelFactory.CreateChannel();
+
+            var response = await client.DeleteWarframe(id, cancellationToken);
+            Console.WriteLine($"Gateway: DELETE response - Success: {response.Success}, Message: {response.Message}");
+            return response.Success;
+        }
+        catch (System.ServiceModel.FaultException ex)
+        {
+            Console.WriteLine($"Gateway: FaultException caught - {ex.Message}");
+            throw new WarframeNotFoundException(id);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Gateway: Unexpected exception - {ex.GetType().Name}: {ex.Message}");
+            throw;
         }
     }
 

--- a/CodexApi/Infrastructure/Soap/Contracts/IWarframeServiceContract.cs
+++ b/CodexApi/Infrastructure/Soap/Contracts/IWarframeServiceContract.cs
@@ -6,6 +6,22 @@ namespace CodexApi.Infrastructure.Soap.Contracts;
 [ServiceContract(Name = "WarframeService", Namespace = "http://Warframe-api/Warframe-service")]
 public interface IWarframeServiceContract
 {
+
     [OperationContract]
     Task<WarframeResponseDto> GetWarframeById(Guid id, CancellationToken cancellationToken);
+
+    [OperationContract]
+    Task<PagedResultDto<WarframeResponseDto>> GetWarframes(int page, int pageSize, string name, CancellationToken cancellationToken);
+
+    [OperationContract]
+    Task<WarframeResponseDto> CreateWarframe(CreateWarframeDto warframeDto, CancellationToken cancellationToken);
+
+    [OperationContract]
+    Task<WarframeResponseDto> UpdateWarframe(Guid id, CreateWarframeDto warframeDto, CancellationToken cancellationToken);
+
+    [OperationContract]
+    Task<WarframeResponseDto> PatchWarframe(Guid id, CreateWarframeDto warframeDto, CancellationToken cancellationToken);
+
+    [OperationContract]
+    Task<DeleteWarframeResponseDto> DeleteWarframe(Guid id, CancellationToken cancellationToken);
 }

--- a/CodexApi/Infrastructure/Soap/Dtos/CreateWarframeDto.cs
+++ b/CodexApi/Infrastructure/Soap/Dtos/CreateWarframeDto.cs
@@ -1,6 +1,6 @@
 using System.Runtime.Serialization;
 
-namespace WarframeApi.Dtos;
+namespace CodexApi.Infrastructure.Soap.Dtos;
 
 [DataContract(Name = "CreateWarframeDto", Namespace = "http://Warframe-api/Warframe-service")]
 public class CreateWarframeDto

--- a/CodexApi/Infrastructure/Soap/Dtos/DeleteWarframeResponseDto.cs
+++ b/CodexApi/Infrastructure/Soap/Dtos/DeleteWarframeResponseDto.cs
@@ -1,13 +1,13 @@
 using System.Runtime.Serialization;
 
-namespace WarframeApi.Dtos;
+namespace CodexApi.Infrastructure.Soap.Dtos;
 
 [DataContract(Name = "DeleteWarframeResponse", Namespace = "http://Warframe-api/Warframe-service")]
 public class DeleteWarframeResponseDto
 {
-    [DataMember(Name = "Success", Order = 1)]
+    [DataMember(Order = 1)]
     public bool Success { get; set; }
     
-    [DataMember(Name = "Message", Order = 2)]
+    [DataMember(Order = 2)]
     public string Message { get; set; } = string.Empty;
 }

--- a/CodexApi/Infrastructure/Soap/Dtos/PagedResultDto.cs
+++ b/CodexApi/Infrastructure/Soap/Dtos/PagedResultDto.cs
@@ -1,0 +1,30 @@
+using System.Runtime.Serialization;
+
+namespace CodexApi.Infrastructure.Soap.Dtos;
+
+
+[DataContract(Name = "PagedResult", Namespace = "http://Warframe-api/Warframe-service")]
+public class PagedResultDto<T>
+{
+
+    [DataMember(Order = 1)]
+    public IList<T> Items { get; set; } = new List<T>();
+
+    [DataMember(Order = 2)]
+    public int PageNumber { get; set; }
+
+    [DataMember(Order = 3)]
+    public int PageSize { get; set; }
+
+    [DataMember(Order = 4)]
+    public int TotalCount { get; set; }
+
+    [DataMember(Order = 5)]
+    public int TotalPages { get; set; }
+
+    [DataMember(Order = 6)]
+    public bool HasNextPage { get; set; }
+
+    [DataMember(Order = 7)]
+    public bool HasPreviousPage { get; set; }
+}

--- a/CodexApi/Infrastructure/Soap/Dtos/PaginationRequestDto.cs
+++ b/CodexApi/Infrastructure/Soap/Dtos/PaginationRequestDto.cs
@@ -1,0 +1,15 @@
+using System.Runtime.Serialization;
+
+namespace CodexApi.Infrastructure.Soap.Dtos;
+
+
+[DataContract(Name = "PaginationRequest", Namespace = "http://Warframe-api/Warframe-service")]
+public class PaginationRequestDto
+{
+
+    [DataMember(Order = 1)]
+    public int PageNumber { get; set; } = 1;
+    
+    [DataMember(Order = 2)]
+    public int PageSize { get; set; } = 10;
+}

--- a/CodexApi/Infrastructure/Soap/Dtos/StatsDto.cs
+++ b/CodexApi/Infrastructure/Soap/Dtos/StatsDto.cs
@@ -1,6 +1,6 @@
 using System.Runtime.Serialization;
 
-namespace WarframeApi.Dtos;
+namespace CodexApi.Infrastructure.Soap.Dtos;
 
 [DataContract(Name = "StatsDto", Namespace = "http://Warframe-api/Warframe-service")]
 public class StatsDto

--- a/CodexApi/Infrastructure/Soap/Dtos/UpdateWarframeResponseDto.cs
+++ b/CodexApi/Infrastructure/Soap/Dtos/UpdateWarframeResponseDto.cs
@@ -1,0 +1,13 @@
+using System.Runtime.Serialization;
+
+namespace CodexApi.Infrastructure.Soap.Dtos;
+
+[DataContract(Name = "UpdateWarframeResponse", Namespace = "http://Warframe-api/Warframe-service")]
+public class UpdateWarframeResponseDto
+{
+    [DataMember(Order = 1)]
+    public bool Success { get; set; }
+    
+    [DataMember(Order = 2)]
+    public string Message { get; set; } = string.Empty;
+}

--- a/CodexApi/Mappers/WarframeMapper.cs
+++ b/CodexApi/Mappers/WarframeMapper.cs
@@ -27,4 +27,60 @@ public static class WarframeMapper
             Energy = stats.Energy
         };
     }
+
+    public static Warframe ToModel(this CreateWarframeRequest request)
+    {
+        return new Warframe
+        {
+            Id = Guid.NewGuid(),
+            Name = request.Name,
+            Rol = request.Rol,
+            Rank = request.Rank,
+            Stats = new Stats
+            {
+                Hp = request.Stats.Hp,
+                Shield = request.Stats.Shield,
+                Armor = request.Stats.Armor,
+                Energy = request.Stats.Energy
+            }
+        };
+    }
+
+    public static void UpdateFrom(this Warframe warframe, UpdateWarframeRequest request)
+    {
+        warframe.Name = request.Name;
+        warframe.Rol = request.Rol;
+        warframe.Rank = request.Rank;
+        warframe.Stats.Hp = request.Stats.Hp;
+        warframe.Stats.Shield = request.Stats.Shield;
+        warframe.Stats.Armor = request.Stats.Armor;
+        warframe.Stats.Energy = request.Stats.Energy;
+    }
+
+    public static void PatchFrom(this Warframe warframe, PatchWarframeRequest request)
+    {
+        if (!string.IsNullOrEmpty(request.Name))
+            warframe.Name = request.Name;
+            
+        if (!string.IsNullOrEmpty(request.Rol))
+            warframe.Rol = request.Rol;
+            
+        if (request.Rank.HasValue)
+            warframe.Rank = request.Rank.Value;
+
+        if (request.Stats != null)
+        {
+            if (request.Stats.Hp.HasValue)
+                warframe.Stats.Hp = request.Stats.Hp.Value;
+                
+            if (request.Stats.Shield.HasValue)
+                warframe.Stats.Shield = request.Stats.Shield.Value;
+                
+            if (request.Stats.Armor.HasValue)
+                warframe.Stats.Armor = request.Stats.Armor.Value;
+                
+            if (request.Stats.Energy.HasValue)
+                warframe.Stats.Energy = request.Stats.Energy.Value;
+        }
+    }
 }

--- a/CodexApi/Services/IWarframeService.cs
+++ b/CodexApi/Services/IWarframeService.cs
@@ -1,8 +1,14 @@
 using CodexApi.Models;
+using CodexApi.Dtos;
 
 namespace CodexApi.Services;
 
 public interface IWarframeService
 {
-    Task<Warframe?> GetWarframeByIdAsync(Guid id, CancellationToken cancellationToken);
+    Task<Warframe> GetWarframeByIdAsync(Guid id, CancellationToken cancellationToken);
+    Task<IEnumerable<Warframe>> GetWarframesAsync(int page, int pageSize, string name, CancellationToken cancellationToken);
+    Task<Warframe> CreateWarframeAsync(CreateWarframeRequest request, CancellationToken cancellationToken);
+    Task<Warframe> UpdateWarframeAsync(Guid id, UpdateWarframeRequest request, CancellationToken cancellationToken);
+    Task<Warframe> PatchWarframeAsync(Guid id, PatchWarframeRequest request, CancellationToken cancellationToken);
+    Task DeleteWarframeAsync(Guid id, CancellationToken cancellationToken);
 }

--- a/CodexApi/Services/WarframeService.cs
+++ b/CodexApi/Services/WarframeService.cs
@@ -1,5 +1,7 @@
 using CodexApi.Models;
 using CodexApi.Gateways;
+using CodexApi.Dtos;
+using CodexApi.Exceptions;
 
 namespace CodexApi.Services;
 
@@ -12,8 +14,103 @@ public class WarframeService : IWarframeService
         _warframeGateway = warframeGateway;
     }
 
-    public async Task<Warframe?> GetWarframeByIdAsync(Guid id, CancellationToken cancellationToken)
+    public async Task<Warframe> GetWarframeByIdAsync(Guid id, CancellationToken cancellationToken)
     {
-        return await _warframeGateway.GetWarframeByIdAsync(id, cancellationToken);
+        var warframe = await _warframeGateway.GetWarframeByIdAsync(id, cancellationToken);
+        if (warframe is null)
+        {
+            throw new WarframeNotFoundException(id);
+        }
+        return warframe;
+    }
+
+    public async Task<IEnumerable<Warframe>> GetWarframesAsync(int page, int pageSize, string name, CancellationToken cancellationToken)
+    {
+        return await _warframeGateway.GetWarframesAsync(page, pageSize, name, cancellationToken);
+    }
+
+    public async Task<Warframe> CreateWarframeAsync(CreateWarframeRequest request, CancellationToken cancellationToken)
+    {
+
+        if (string.IsNullOrWhiteSpace(request.Name))
+        {
+            throw new ValidationException("name", "Name cannot be empty or whitespace");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Rol))
+        {
+            throw new ValidationException("rol", "Role cannot be empty or whitespace");
+        }
+
+        try
+        {
+            return await _warframeGateway.CreateWarframeAsync(request, cancellationToken);
+        }
+        catch (Exception ex) when (ex.Message.Contains("already exists"))
+        {
+            throw new WarframeAlreadyExistsException(request.Name);
+        }
+    }
+
+    public async Task<Warframe> UpdateWarframeAsync(Guid id, UpdateWarframeRequest request, CancellationToken cancellationToken)
+    {
+        if (id == Guid.Empty)
+        {
+            throw new ArgumentException("Warframe ID cannot be empty", nameof(id));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Name))
+        {
+            throw new ValidationException("name", "Name cannot be empty or whitespace");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Rol))
+        {
+            throw new ValidationException("rol", "Role cannot be empty or whitespace");
+        }
+
+        var success = await _warframeGateway.UpdateWarframeAsync(id, request, cancellationToken);
+        if (!success)
+        {
+            throw new WarframeNotFoundException(id);
+        }
+
+        return await GetWarframeByIdAsync(id, cancellationToken);
+    }
+
+    public async Task<Warframe> PatchWarframeAsync(Guid id, PatchWarframeRequest request, CancellationToken cancellationToken)
+    {
+        if (id == Guid.Empty)
+        {
+            throw new ArgumentException("Warframe ID cannot be empty", nameof(id));
+        }
+
+        // Validate that at least one field is provided for patching
+        if (request.Name == null && request.Rol == null && request.Rank == null && request.Stats == null)
+        {
+            throw new ValidationException("request", "At least one field must be provided for updating");
+        }
+
+        var success = await _warframeGateway.PatchWarframeAsync(id, request, cancellationToken);
+        if (!success)
+        {
+            throw new WarframeNotFoundException(id);
+        }
+
+        return await GetWarframeByIdAsync(id, cancellationToken);
+    }
+
+    public async Task DeleteWarframeAsync(Guid id, CancellationToken cancellationToken)
+    {
+        if (id == Guid.Empty)
+        {
+            throw new ArgumentException("Warframe ID cannot be empty", nameof(id));
+        }
+
+        var success = await _warframeGateway.DeleteWarframeAsync(id, cancellationToken);
+        if (!success)
+        {
+            throw new WarframeNotFoundException(id);
+        }
     }
 }

--- a/WarframeApi/Contracts/IWarframeServices.cs
+++ b/WarframeApi/Contracts/IWarframeServices.cs
@@ -7,7 +7,7 @@ namespace WarframeApi.Services;
 public interface IWarframeService
 {
     [OperationContract]
-    Task<WarframeResponseDto> CreateWarframe(CreateWarframeDto Warframe, CancellationToken cancellationToken);
+    Task<WarframeResponseDto> CreateWarframe(CreateWarframeDto warframeDto, CancellationToken cancellationToken);
 
     [OperationContract]
     Task<WarframeResponseDto> GetWarframeById(Guid id, CancellationToken cancellationToken);
@@ -16,12 +16,21 @@ public interface IWarframeService
     Task<DeleteWarframeResponseDto> DeleteWarframe(Guid id, CancellationToken cancellationToken);
 
     [OperationContract]
-    Task<WarframeResponseDto> UpdateWarframe(UpdateWarframeDto Warframe, CancellationToken cancellationToken);
+    Task<WarframeResponseDto> UpdateWarframe(Guid id, CreateWarframeDto warframeDto, CancellationToken cancellationToken);
+
+    [OperationContract]
+    Task<WarframeResponseDto> PatchWarframe(Guid id, CreateWarframeDto warframeDto, CancellationToken cancellationToken);
 
     [OperationContract]
     Task<List<WarframeResponseDto>> GetWarframeByName(string name, CancellationToken cancellationToken);
 
     [OperationContract]
     Task<List<WarframeResponseDto>> GetWarframeByRank(int rank, CancellationToken cancellationToken);
+
+    [OperationContract]
+    Task<PagedResultDto<WarframeResponseDto>> GetWarframeByNamePaged(string name, PaginationRequestDto pagination, CancellationToken cancellationToken);
+
+    [OperationContract]
+    Task<PagedResultDto<WarframeResponseDto>> GetWarframes(int page, int pageSize, string name, CancellationToken cancellationToken);
 
 }

--- a/WarframeApi/Dtos/PagedResultDto.cs
+++ b/WarframeApi/Dtos/PagedResultDto.cs
@@ -1,0 +1,28 @@
+using System.Runtime.Serialization;
+
+namespace WarframeApi.Dtos;
+
+[DataContract(Name = "PagedResult", Namespace = "http://Warframe-api/Warframe-service")]
+public class PagedResultDto<T>
+{
+    [DataMember(Order = 1)]
+    public IList<T> Items { get; set; } = new List<T>();
+    
+    [DataMember(Order = 2)]
+    public int PageNumber { get; set; }
+    
+    [DataMember(Order = 3)]
+    public int PageSize { get; set; }
+    
+    [DataMember(Order = 4)]
+    public int TotalCount { get; set; }
+    
+    [DataMember(Order = 5)]
+    public int TotalPages { get; set; }
+    
+    [DataMember(Order = 6)]
+    public bool HasNextPage { get; set; }
+    
+    [DataMember(Order = 7)]
+    public bool HasPreviousPage { get; set; }
+}

--- a/WarframeApi/Dtos/PaginationRequestDto.cs
+++ b/WarframeApi/Dtos/PaginationRequestDto.cs
@@ -1,0 +1,13 @@
+using System.Runtime.Serialization;
+
+namespace WarframeApi.Dtos;
+
+[DataContract(Name = "PaginationRequest", Namespace = "http://Warframe-api/Warframe-service")]
+public class PaginationRequestDto
+{
+    [DataMember(Order = 1)]
+    public int PageNumber { get; set; } = 1;
+    
+    [DataMember(Order = 2)]
+    public int PageSize { get; set; } = 10;
+}

--- a/WarframeApi/Mappers/WarframeMapper.cs
+++ b/WarframeApi/Mappers/WarframeMapper.cs
@@ -20,14 +20,14 @@ public static class WarframeMapper
     {
         if (warframeEntity is null)
         {
-            return null;
+            throw new ArgumentNullException(nameof(warframeEntity), "WarframeEntity cannot be null");
         }
 
         return new Warframe
         {
             Id = warframeEntity.Id,
-            Name = warframeEntity.Name,
-            Rol = warframeEntity.Rol,
+            Name = warframeEntity.Name ?? string.Empty,
+            Rol = warframeEntity.Rol ?? string.Empty,
             Rank = warframeEntity.Rank,
             Stats = new Stats
             {
@@ -43,14 +43,19 @@ public static class WarframeMapper
     {
         if (warframe is null)
         {
-            return null;
+            throw new ArgumentNullException(nameof(warframe), "Warframe cannot be null");
+        }
+
+        if (warframe.Stats is null)
+        {
+            throw new ArgumentException("Warframe Stats cannot be null", nameof(warframe));
         }
 
         return new WarframeEntity
         {
             Id = warframe.Id,
-            Name = warframe.Name,
-            Rol = warframe.Rol,
+            Name = warframe.Name ?? string.Empty,
+            Rol = warframe.Rol ?? string.Empty,
             Rank = warframe.Rank,
             Hp = warframe.Stats.Hp,
             Shield = warframe.Stats.Shield,
@@ -63,14 +68,19 @@ public static class WarframeMapper
     {
         if (createWarframeDto is null)
         {
-            return null;
+            throw new ArgumentNullException(nameof(createWarframeDto), "CreateWarframeDto cannot be null");
+        }
+
+        if (createWarframeDto.Stats is null)
+        {
+            throw new ArgumentException("CreateWarframeDto Stats cannot be null", nameof(createWarframeDto));
         }
 
         return new Warframe
         {
             Id = Guid.NewGuid(),
-            Name = createWarframeDto.Name,
-            Rol = createWarframeDto.Rol,
+            Name = createWarframeDto.Name ?? string.Empty,
+            Rol = createWarframeDto.Rol ?? string.Empty,
             Rank = createWarframeDto.Rank,
             Stats = new Stats
             {
@@ -86,14 +96,19 @@ public static class WarframeMapper
     {
         if (warframe is null)
         {
-            return null;
+            throw new ArgumentNullException(nameof(warframe), "Warframe cannot be null");
+        }
+
+        if (warframe.Stats is null)
+        {
+            throw new ArgumentException("Warframe Stats cannot be null", nameof(warframe));
         }
 
         return new WarframeResponseDto
         {
             Id = warframe.Id,
-            Name = warframe.Name,
-            Rol = warframe.Rol,
+            Name = warframe.Name ?? string.Empty,
+            Rol = warframe.Rol ?? string.Empty,
             Rank = warframe.Rank,
             Hp = warframe.Stats.Hp,
             Shield = warframe.Stats.Shield,

--- a/WarframeApi/Repositories/IWarframeRepository.cs
+++ b/WarframeApi/Repositories/IWarframeRepository.cs
@@ -19,5 +19,7 @@ public interface IWarframeRepository
 
     Task<IReadOnlyList<Warframe>> GetWarframesByRankAsync(int rank, CancellationToken cancellationToken);
 
+    Task<(IReadOnlyList<Warframe> Items, int TotalCount)> GetWarframesByNamePagedAsync(string name, int pageNumber, int pageSize, CancellationToken cancellationToken);
+
 
 }

--- a/WarframeApi/Services/WarframeService.cs
+++ b/WarframeApi/Services/WarframeService.cs
@@ -29,21 +29,29 @@ public class WarframeService : IWarframeService
         return warframes.ToResponseDto().ToList();
     }
 
-    public async Task<WarframeResponseDto> UpdateWarframe(UpdateWarframeDto warframeToUpdate, CancellationToken cancellationToken)
+    public async Task<WarframeResponseDto> UpdateWarframe(Guid id, CreateWarframeDto warframeToUpdate, CancellationToken cancellationToken)
     {
-        var warframe = await _warframeRepository.GetWarframesByIdAsync(warframeToUpdate.Id, cancellationToken);
+        Console.WriteLine($"UpdateWarframe called with ID: {id}, DTO: {warframeToUpdate?.Name ?? "null"}");
+        
+        if (warframeToUpdate is null)
+        {
+            throw new FaultException("UpdateWarframeDto cannot be null. Check SOAP message format and serialization.");
+        }
+
+        var warframe = await _warframeRepository.GetWarframesByIdAsync(id, cancellationToken);
         if (warframe == null)
         {
-            throw new FaultException($"No Warframe with {warframeToUpdate.Id} ID found.");
+            throw new FaultException($"No Warframe with {id} ID found.");
         }
-        if (!await IsUpdatable(warframeToUpdate, cancellationToken))
+        
+        if (!await IsUpdatable(id, warframeToUpdate, cancellationToken))
         {
             throw new FaultException($"Another Warframe with name {warframeToUpdate.Name} already exists.");
         }
 
         warframe.Name = warframeToUpdate.Name;
         warframe.Rank = warframeToUpdate.Rank;
-        warframe.Rol = warframeToUpdate.Role;
+        warframe.Rol = warframeToUpdate.Rol;
         warframe.Stats.Hp = warframeToUpdate.Stats.Hp;
         warframe.Stats.Shield = warframeToUpdate.Stats.Shield;
         warframe.Stats.Armor = warframeToUpdate.Stats.Armor;
@@ -53,15 +61,72 @@ public class WarframeService : IWarframeService
         return warframe.ToResponseDto();
     }
 
-    private async Task<bool> IsUpdatable(UpdateWarframeDto WarframeToUpdate, CancellationToken cancellationToken)
+    public async Task<WarframeResponseDto> PatchWarframe(Guid id, CreateWarframeDto warframeToPatch, CancellationToken cancellationToken)
     {
-        var duplicatedWarframe = await _warframeRepository.GetWFByNameAsync(WarframeToUpdate.Name, cancellationToken);
-        return duplicatedWarframe is null || IsTheSameWarframe(duplicatedWarframe, WarframeToUpdate);
+        Console.WriteLine($"PatchWarframe called with ID: {id}, DTO: {warframeToPatch?.Name ?? "null"}");
+        
+        if (warframeToPatch is null)
+        {
+            throw new FaultException("PatchWarframeDto cannot be null. Check SOAP message format and serialization.");
+        }
+
+        var warframe = await _warframeRepository.GetWarframesByIdAsync(id, cancellationToken);
+        if (warframe == null)
+        {
+            throw new FaultException($"No Warframe with {id} ID found.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(warframeToPatch.Name))
+        {
+            if (warframe.Name != warframeToPatch.Name)
+            {
+                var duplicatedWarframe = await _warframeRepository.GetWFByNameAsync(warframeToPatch.Name, cancellationToken);
+                if (duplicatedWarframe != null)
+                {
+                    throw new FaultException($"Another Warframe with name {warframeToPatch.Name} already exists.");
+                }
+            }
+            warframe.Name = warframeToPatch.Name;
+        }
+
+        if (!string.IsNullOrWhiteSpace(warframeToPatch.Rol))
+        {
+            warframe.Rol = warframeToPatch.Rol;
+        }
+
+        if (warframeToPatch.Rank > 0)
+        {
+            warframe.Rank = warframeToPatch.Rank;
+        }
+
+        if (warframeToPatch.Stats != null)
+        {
+            if (warframeToPatch.Stats.Hp > 0)
+                warframe.Stats.Hp = warframeToPatch.Stats.Hp;
+            
+            if (warframeToPatch.Stats.Shield > 0)
+                warframe.Stats.Shield = warframeToPatch.Stats.Shield;
+            
+            if (warframeToPatch.Stats.Armor > 0)
+                warframe.Stats.Armor = warframeToPatch.Stats.Armor;
+            
+            if (warframeToPatch.Stats.Energy > 0)
+                warframe.Stats.Energy = warframeToPatch.Stats.Energy;
+        }
+
+        await _warframeRepository.UpdateWarframeAsync(warframe, cancellationToken);
+        return warframe.ToResponseDto();
     }
 
-    private static bool IsTheSameWarframe(Warframe warframe, UpdateWarframeDto warframeToUpdate)
+    private async Task<bool> IsUpdatable(Guid id, CreateWarframeDto warframeToUpdate, CancellationToken cancellationToken)
     {
-        return warframe.Id == warframeToUpdate.Id;
+        var duplicatedWarframe = await _warframeRepository.GetWFByNameAsync(warframeToUpdate.Name, cancellationToken);
+        return duplicatedWarframe is null || IsTheSameWarframe(duplicatedWarframe, id);
+    }
+
+    private static bool IsTheSameWarframe(Warframe warframe, Guid id)
+    {
+        return warframe.Id == id;
     }
 
     public async Task<DeleteWarframeResponseDto> DeleteWarframe(Guid id, CancellationToken cancellationToken)
@@ -73,7 +138,11 @@ public class WarframeService : IWarframeService
         }
 
         await _warframeRepository.DeleteWarframeAsync(warframe, cancellationToken);
-        return new DeleteWarframeResponseDto { Success = true };
+        return new DeleteWarframeResponseDto 
+        { 
+            Success = true, 
+            Message = $"Warframe with ID {id} deleted successfully." 
+        };
     }
 
     public async Task<WarframeResponseDto> GetWarframeById(Guid id, CancellationToken cancellationToken)
@@ -88,18 +157,76 @@ public class WarframeService : IWarframeService
 
     public async Task<WarframeResponseDto> CreateWarframe(CreateWarframeDto warframeDto, CancellationToken cancellationToken)
     {
-        warframeDto.ValidateRequiredFields();
+        try
+        {
+            Console.WriteLine($"CreateWarframe called with: {warframeDto?.Name ?? "null DTO"}");
+            
+            if (warframeDto is null)
+            {
+                throw new FaultException("CreateWarframeDto cannot be null. Check SOAP message format and serialization.");
+            }
 
-        warframeDto
-            .ValidateName()
-            .ValidateRol()
-            .ValidateRank()
-            .ValidateStats();
+            warframeDto.ValidateRequiredFields();
 
-        var warframe = warframeDto.ToModel();
+            warframeDto
+                .ValidateName()
+                .ValidateRol()
+                .ValidateRank()
+                .ValidateStats();
 
-        var createdWarframe = await _warframeRepository.CreateAsync(warframe, cancellationToken);
+            var warframe = warframeDto.ToModel();
 
-        return createdWarframe.ToResponseDto();
+            var createdWarframe = await _warframeRepository.CreateAsync(warframe, cancellationToken);
+
+            return createdWarframe.ToResponseDto();
+        }
+        catch (ArgumentNullException ex)
+        {
+            throw new FaultException($"Invalid request: {ex.Message}");
+        }
+        catch (ArgumentException ex)
+        {
+            throw new FaultException($"Invalid data: {ex.Message}");
+        }
+        catch (FaultException)
+        {
+            throw; 
+        }
+        catch (Exception ex)
+        {
+            throw new FaultException($"An error occurred while creating the warframe: {ex.Message}");
+        }
+    }
+
+    public async Task<PagedResultDto<WarframeResponseDto>> GetWarframeByNamePaged(string name, PaginationRequestDto pagination, CancellationToken cancellationToken)
+    {
+        var (items, totalCount) = await _warframeRepository.GetWarframesByNamePagedAsync(name, pagination.PageNumber, pagination.PageSize, cancellationToken);
+        
+        return new PagedResultDto<WarframeResponseDto>
+        {
+            Items = items.ToResponseDto().ToList(),
+            PageNumber = pagination.PageNumber,
+            PageSize = pagination.PageSize,
+            TotalCount = totalCount,
+            TotalPages = (int)Math.Ceiling((double)totalCount / pagination.PageSize),
+            HasNextPage = pagination.PageNumber * pagination.PageSize < totalCount,
+            HasPreviousPage = pagination.PageNumber > 1
+        };
+    }
+
+    public async Task<PagedResultDto<WarframeResponseDto>> GetWarframes(int page, int pageSize, string name, CancellationToken cancellationToken)
+    {
+        var (items, totalCount) = await _warframeRepository.GetWarframesByNamePagedAsync(name, page, pageSize, cancellationToken);
+        
+        return new PagedResultDto<WarframeResponseDto>
+        {
+            Items = items.ToResponseDto().ToList(),
+            PageNumber = page,
+            PageSize = pageSize,
+            TotalCount = totalCount,
+            TotalPages = (int)Math.Ceiling((double)totalCount / pageSize),
+            HasNextPage = page * pageSize < totalCount,
+            HasPreviousPage = page > 1
+        };
     }
 }

--- a/WarframeApi/Validations/WarframeValidator.cs
+++ b/WarframeApi/Validations/WarframeValidator.cs
@@ -7,10 +7,13 @@ public static class WarframeValidator
 {
     public static CreateWarframeDto ValidateRequiredFields(this CreateWarframeDto warframe)
     {
-        if (string.IsNullOrEmpty(warframe.Name))
+        if (warframe is null)
+            throw new FaultException("Warframe data is required and cannot be null");
+            
+        if (string.IsNullOrWhiteSpace(warframe.Name))
             throw new FaultException("Warframe name is required and cannot be empty");
             
-        if (string.IsNullOrEmpty(warframe.Rol))
+        if (string.IsNullOrWhiteSpace(warframe.Rol))
             throw new FaultException("Warframe Rol is required and cannot be empty");
             
         if (warframe.Stats == null)
@@ -20,17 +23,20 @@ public static class WarframeValidator
     }
 
     public static CreateWarframeDto ValidateName(this CreateWarframeDto warframe) =>
-        string.IsNullOrEmpty(warframe.Name)
+        string.IsNullOrWhiteSpace(warframe?.Name)
             ? throw new FaultException("Warframe name is required")
             : warframe;
 
     public static CreateWarframeDto ValidateRol(this CreateWarframeDto warframe) =>
-        string.IsNullOrEmpty(warframe.Rol)
+        string.IsNullOrWhiteSpace(warframe?.Rol)
             ? throw new FaultException("Warframe Rol is required")
             : warframe;
         
     public static CreateWarframeDto ValidateRank(this CreateWarframeDto warframe)
     {
+        if (warframe is null)
+            throw new FaultException("Warframe data is required");
+            
         if (warframe.Rank < 0 || warframe.Rank > 30)
         {
             throw new FaultException("Warframe Rank must be between 0 and 30 (inclusive)");
@@ -39,8 +45,27 @@ public static class WarframeValidator
         return warframe;
     }
 
-    public static CreateWarframeDto ValidateStats(this CreateWarframeDto warframe) =>
-        warframe.Stats == null
-            ? throw new FaultException("Warframe Stats are required")
-            : warframe;
+    public static CreateWarframeDto ValidateStats(this CreateWarframeDto warframe)
+    {
+        if (warframe is null)
+            throw new FaultException("Warframe data is required");
+            
+        if (warframe.Stats == null)
+            throw new FaultException("Warframe Stats are required");
+            
+        // Validate individual stat values
+        if (warframe.Stats.Hp < 0)
+            throw new FaultException("Warframe HP must be a positive value");
+            
+        if (warframe.Stats.Shield < 0)
+            throw new FaultException("Warframe Shield must be a positive value");
+            
+        if (warframe.Stats.Armor < 0)
+            throw new FaultException("Warframe Armor must be a positive value");
+            
+        if (warframe.Stats.Energy < 0)
+            throw new FaultException("Warframe Energy must be a positive value");
+            
+        return warframe;
+    }
 }


### PR DESCRIPTION
- Added methods in IWarframeGateway for creating, updating, patching, and deleting Warframes.
- Implemented GetWarframesAsync for paginated retrieval of Warframes.
- Enhanced WarframeGateway to handle new operations with appropriate error handling.
- Introduced new DTOs for Create, Update, and Delete operations.
- Updated WarframeMapper to support mapping between DTOs and domain models.
- Enhanced WarframeService to validate inputs and handle exceptions for CRUD operations.
- Added pagination support in WarframeRepository for retrieving Warframes by name.
- Improved validation logic for CreateWarframeDto to ensure required fields are present.